### PR TITLE
Switch to country_code_picker package

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:intl_phone_field/countries.dart';
+import 'package:country_code_picker/country_code_picker.dart';
 import 'models/login_phone_model.dart';
 import 'widgets/phone_input_row.dart';
 import 'theme/theme.dart';
@@ -34,12 +34,11 @@ class _PhoneInputPageState extends State<PhoneInputPage> {
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: PhoneInputRow(
-          selectedCountry: countries.firstWhere(
-            (c) => c.code == model.countryCode,
-            orElse: () => countries.firstWhere((c) => c.code == 'TR'),
-          ),
+          selectedCountry:
+              CountryCode.tryFromCountryCode(model.countryCode) ??
+                  CountryCode.fromCountryCode('TR'),
           onCountryChanged: (country) {
-            setState(() => model.countryCode = country.code);
+            setState(() => model.countryCode = country.code ?? '');
           },
           phone: model.phoneNumber,
           onPhoneChanged: (value) {

--- a/lib/widgets/phone_input_row.dart
+++ b/lib/widgets/phone_input_row.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:intl_phone_field/countries.dart';
+import 'package:country_code_picker/country_code_picker.dart';
+
+final List<CountryCode> countriesList =
+    codes.map((c) => CountryCode.fromJson(c)).toList();
 
 class PhoneInputRow extends StatelessWidget {
-  final Country selectedCountry;
-  final ValueChanged<Country> onCountryChanged;
+  final CountryCode selectedCountry;
+  final ValueChanged<CountryCode> onCountryChanged;
   final String phone;
   final ValueChanged<String> onPhoneChanged;
 
@@ -31,13 +34,13 @@ class PhoneInputRow extends StatelessWidget {
         children: [
           //bayrak kısmı
           DropdownButtonHideUnderline(
-            child: DropdownButton<Country>(
+            child: DropdownButton<CountryCode>(
               value: selectedCountry,
               icon: const Icon(Icons.keyboard_arrow_down),
-              onChanged: (Country? c) {
+              onChanged: (CountryCode? c) {
                 if (c != null) onCountryChanged(c);
               },
-              items: countries.map((c) {
+              items: countriesList.map((c) {
                 return DropdownMenuItem(
                   value: c,
                   child: Row(
@@ -45,12 +48,12 @@ class PhoneInputRow extends StatelessWidget {
                       CircleAvatar(
                         radius: 12,
                         backgroundImage: AssetImage(
-                          'packages/intl_phone_field/assets/flags/${c.code.toLowerCase()}.png',
+                          'packages/country_code_picker/${c.flagUri}',
                         ),
                         backgroundColor: Colors.transparent,
                       ),
                       const SizedBox(width: 6),
-                      Text(c.dialCode),
+                      Text(c.dialCode ?? ''),
                     ],
                   ),
                 );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,14 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  intl_phone_field:
+  country_code_picker:
     dependency: "direct main"
     description:
-      name: intl_phone_field
-      sha256: "73819d3dfcb68d2c85663606f6842597c3ddf6688ac777f051b17814fe767bbf"
+      name: country_code_picker
+      sha256: ee216486da1db8e3c5688f9650c99472ab6a4025ed1ea0c5a54ae6063143d90d
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   # telefon alanında ülke seçim yeri
-  intl_phone_field: ^3.2.0
+  country_code_picker: ^3.3.0
   provider: ^6.0.5
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- replace `intl_phone_field` with `country_code_picker`
- adapt phone input widget to use `country_code_picker`
- update references in example code

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d5d0a6508327addc84b8bb952b4a